### PR TITLE
[FEAT]: Unix Support in DateTime Picker Component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@boltic/cli",
-	"version": "1.0.35",
+	"version": "1.0.36",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@boltic/cli",
-			"version": "1.0.35",
+			"version": "1.0.36",
 			"cpu": [
 				"x64",
 				"arm64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@boltic/cli",
-	"version": "1.0.35",
+	"version": "1.0.36",
 	"description": "A powerful CLI tool for managing Boltic Workflow integrations - create, sync, test, and publish integrations with ease",
 	"main": "index.js",
 	"bin": {

--- a/templates/component-schemas.js
+++ b/templates/component-schemas.js
@@ -711,6 +711,8 @@ const date = {
 			views: undefined,
 			timeSteps: { hours: 1, minutes: 5, seconds: 5 },
 			allowDynamic: false,
+			outputFormat: "YYYY-MM-DD",
+			unixUnit: "milliseconds",
 		},
 		validation: {
 			required: false,


### PR DESCRIPTION
The P.R. add Unix Timestamp support in date-time picker component. User needs to add this key in `htmlProps` inside meta.