### PR TITLE
Fixed MCP setup so `--header` values are preserved in generated MCP configuration

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -25,6 +25,12 @@ jobs:
                   node-version: 20
                   registry-url: https://registry.npmjs.org/
             - run: npm ci
-            - run: npm publish
+            - run: |
+                  VERSION=$(node -p "require('./package.json').version")
+                  if [[ "$VERSION" == *-* ]]; then
+                    npm publish --access public --tag next
+                  else
+                    npm publish --access public
+                  fi
               env:
                   NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.0.46
+## 1.0.46-dev.0.1
 
 ### Fixed
 - Fixed MCP setup so `--header` values are preserved in generated MCP configuration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.0.46-dev.0.1
+## 1.0.46
 
 ### Fixed
 - Fixed MCP setup so `--header` values are preserved in generated MCP configuration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 1.0.46
+
+### Fixed
+- Fixed MCP setup so `--header` values are preserved in generated MCP configuration.
+- Ensured Cursor SSE-style MCP entries now save authentication headers correctly.
+- Added regression coverage for header persistence in the MCP setup flow.
+
+### Issue
+- MCP setup was dropping custom header values, preventing auth headers from being written for Cursor and other MCP client configurations.

--- a/__tests__/mcp.test.js
+++ b/__tests__/mcp.test.js
@@ -150,6 +150,37 @@ describe("MCP Commands", () => {
 		expect(json.mcpServers.curSrv).toEqual({ url: "https://sse" });
 	});
 
+	it("writes Cursor config with parsed headers", async () => {
+		const { default: Mcp } = await import("../commands/mcp.js");
+		const writes = [];
+		jest.mocked(fs.existsSync).mockReturnValue(false);
+		jest.mocked(fs.mkdirSync).mockImplementation(() => {});
+		jest.mocked(fs.readFileSync).mockImplementation(() => "{}\n");
+		jest.mocked(fs.writeFileSync).mockImplementation((p, c) =>
+			writes.push({ p, c })
+		);
+
+		await Mcp.execute([
+			"setup",
+			"https://sse",
+			"cursorSrv",
+			"--client",
+			"cursor",
+			"--header",
+			"Authorization: Bearer abc123",
+		]);
+
+		const last = writes[writes.length - 1];
+		expect(last.p).toMatch(/\.cursor\/mcp\.json$/);
+		const json = JSON.parse(last.c);
+		expect(json.mcpServers.cursorSrv).toEqual({
+			url: "https://sse",
+			headers: {
+				Authorization: "Bearer abc123",
+			},
+		});
+	});
+
 	it("writes LibreChat YAML file (content generation delegated)", async () => {
 		const { default: Mcp } = await import("../commands/mcp.js");
 		const writes = [];

--- a/commands/mcp.js
+++ b/commands/mcp.js
@@ -57,8 +57,9 @@ async function handleSetup(args) {
 	const url = args[0];
 	let name = args[1] && !args[1].startsWith("--") ? args[1] : undefined;
 
-	// Parse flags: --client, --name
+	// Parse flags: --client, --name, --header
 	let client = "claude";
+	const headerValues = [];
 	for (let i = 0; i < args.length; i++) {
 		const token = args[i];
 		if (
@@ -79,7 +80,25 @@ async function handleSetup(args) {
 			i++;
 		} else if (token.startsWith("--name=")) {
 			name = token.split("=")[1];
+		} else if (
+			token === "--header" &&
+			args[i + 1] &&
+			!args[i + 1].startsWith("--")
+		) {
+			headerValues.push(args[i + 1]);
+			i++;
+		} else if (token.startsWith("--header=")) {
+			headerValues.push(token.split("=")[1]);
 		}
+	}
+
+	let headers = {};
+	try {
+		headers = parseHeaders(headerValues);
+	} catch (error) {
+		console.log(chalk.red("\n❌ Error occurred while parsing headers:"));
+		console.log(chalk.red(`   ${error.message}`));
+		return;
 	}
 
 	if (!url) {
@@ -103,7 +122,7 @@ async function handleSetup(args) {
 		const mcpUrl = url;
 		const command = `composio --sse "${mcpUrl}"`;
 
-		saveMcpConfig(url, client, newKey, mcpUrl, command);
+		saveMcpConfig(url, client, newKey, mcpUrl, command, headers);
 
 		console.log(
 			chalk.cyan(
@@ -125,7 +144,29 @@ async function handleSetup(args) {
 	}
 }
 
-function saveMcpConfig(url, clientType, name, mcpUrl, command) {
+function parseHeaders(headerValues) {
+	return headerValues.reduce((acc, headerValue) => {
+		const separatorIndex = headerValue.indexOf(":");
+		if (separatorIndex === -1) {
+			throw new Error(
+				`Invalid header format "${headerValue}". Use "Header-Name: value".`
+			);
+		}
+
+		const name = headerValue.slice(0, separatorIndex).trim();
+		const value = headerValue.slice(separatorIndex + 1).trim();
+		if (!name) {
+			throw new Error(
+				`Invalid header format "${headerValue}". Header name cannot be empty.`
+			);
+		}
+
+		acc[name] = value;
+		return acc;
+	}, {});
+}
+
+function saveMcpConfig(url, clientType, name, mcpUrl, command, headers = {}) {
 	const config = {
 		command: "npx",
 		args: ["-y", "mcp-remote", mcpUrl],
@@ -133,6 +174,10 @@ function saveMcpConfig(url, clientType, name, mcpUrl, command) {
 			npm_config_yes: "true",
 		},
 	};
+
+	if (Object.keys(headers).length > 0) {
+		config.headers = headers;
+	}
 
 	const sseConfig = {
 		url: mcpUrl,
@@ -364,6 +409,9 @@ function handleFileClient(clientConfig, serverName, config, mcpUrl) {
 		const sseConfig = {
 			url: mcpUrl,
 		};
+		if (config.headers) {
+			sseConfig.headers = config.headers;
+		}
 		existingConfig.mcpServers[serverName] = sseConfig;
 	} else {
 		existingConfig.mcpServers[serverName] = config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@boltic/cli",
-	"version": "1.0.46-dev.0",
+	"version": "1.0.46-dev.0.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@boltic/cli",
-			"version": "1.0.46-dev.0",
+			"version": "1.0.46-dev.0.1",
 			"cpu": [
 				"x64",
 				"arm64"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@boltic/cli",
-	"version": "1.0.45",
+	"version": "1.0.46-dev.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@boltic/cli",
-			"version": "1.0.45",
+			"version": "1.0.46-dev.0",
 			"cpu": [
 				"x64",
 				"arm64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@boltic/cli",
-	"version": "1.0.45",
+	"version": "1.0.46-dev.0",
 	"description": "Professional CLI for interacting with the Boltic platform — create, manage, and publish integrations, serverless functions, workflows, MCPs, and more with enterprise-grade features and a seamless developer experience",
 	"main": "index.js",
 	"bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@boltic/cli",
-	"version": "1.0.46-dev.0.1",
+	"version": "1.0.46",
 	"description": "Professional CLI for interacting with the Boltic platform — create, manage, and publish integrations, serverless functions, workflows, MCPs, and more with enterprise-grade features and a seamless developer experience",
 	"main": "index.js",
 	"bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@boltic/cli",
-	"version": "1.0.46-dev.0",
+	"version": "1.0.46-dev.0.1",
 	"description": "Professional CLI for interacting with the Boltic platform — create, manage, and publish integrations, serverless functions, workflows, MCPs, and more with enterprise-grade features and a seamless developer experience",
 	"main": "index.js",
 	"bin": {


### PR DESCRIPTION
- Fixed MCP setup so `--header` values are preserved in generated MCP configuration.
- Ensured Cursor SSE-style MCP entries now save authentication headers correctly.
- Added regression coverage for header persistence in the MCP setup flow.