### PR TITLE
fix(cli): pass MCP headers to mcp-remote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,20 @@
 # Changelog
 
+## 1.0.47
+
+### Fixed
+
+- Fixed MCP setup for stdio clients such as Claude so `--header` values are passed to `mcp-remote` as command arguments instead of being written to an ignored `headers` config key.
+- Preserved Cursor SSE-style MCP header persistence while keeping stdio client config compatible with `mcp-remote`.
+
 ## 1.0.46
 
 ### Fixed
+
 - Fixed MCP setup so `--header` values are preserved in generated MCP configuration.
 - Ensured Cursor SSE-style MCP entries now save authentication headers correctly.
 - Added regression coverage for header persistence in the MCP setup flow.
 
 ### Issue
+
 - MCP setup was dropping custom header values, preventing auth headers from being written for Cursor and other MCP client configurations.

--- a/__tests__/mcp.test.js
+++ b/__tests__/mcp.test.js
@@ -495,4 +495,38 @@ describe("MCP Commands", () => {
 		// restore
 		jest.mocked(path.join).mockImplementation((...args) => args.join("/"));
 	});
+
+	it("folds headers into mcp-remote args for stdio clients (claude)", async () => {
+		const { default: Mcp } = await import("../commands/mcp.js");
+		const writes = [];
+		jest.mocked(fs.existsSync).mockReturnValue(false);
+		jest.mocked(fs.mkdirSync).mockImplementation(() => {});
+		jest.mocked(fs.readFileSync).mockImplementation(() => "{}\n");
+		jest.mocked(fs.writeFileSync).mockImplementation((p, c) =>
+			writes.push({ p, c })
+		);
+
+		await Mcp.execute([
+			"setup",
+			"http://sse",
+			"srv",
+			"--client",
+			"claude",
+			"--header",
+			"Authorization: Bearer abc123",
+		]);
+
+		const last = writes[writes.length - 1];
+		const json = JSON.parse(last.c);
+		// header must live in argv, never as a stdio `headers` key
+		expect(json.mcpServers.srv.headers).toBeUndefined();
+		expect(json.mcpServers.srv.args).toEqual(
+			expect.arrayContaining([
+				"mcp-remote",
+				"http://sse",
+				"--header",
+				"Authorization: Bearer abc123",
+			])
+		);
+	});
 });

--- a/commands/mcp.js
+++ b/commands/mcp.js
@@ -175,8 +175,12 @@ function saveMcpConfig(url, clientType, name, mcpUrl, command, headers = {}) {
 		},
 	};
 
+	// mcp-remote reads auth headers from argv, not a config key.
+	// A `headers` key on a stdio (command/args) server is silently ignored.
 	if (Object.keys(headers).length > 0) {
-		config.headers = headers;
+		for (const [name, value] of Object.entries(headers)) {
+			config.args.push("--header", `${name}: ${value}`);
+		}
 	}
 
 	const sseConfig = {
@@ -310,7 +314,7 @@ function saveMcpConfig(url, clientType, name, mcpUrl, command, headers = {}) {
 	} else if (clientConfig.type === "yaml") {
 		handleYamlClient(clientConfig, newKey, config);
 	} else {
-		handleFileClient(clientConfig, newKey, config, mcpUrl);
+		handleFileClient(clientConfig, newKey, config, mcpUrl, headers);
 	}
 }
 
@@ -379,7 +383,13 @@ function handleYamlClient(clientConfig, serverName, config) {
 	console.log(chalk.green(`✅ Configuration saved to: ${clientConfig.path}`));
 }
 
-function handleFileClient(clientConfig, serverName, config, mcpUrl) {
+function handleFileClient(
+	clientConfig,
+	serverName,
+	config,
+	mcpUrl,
+	headers = {}
+) {
 	if (!clientConfig.path) {
 		throw new Error("Path not specified for file client");
 	}
@@ -409,8 +419,8 @@ function handleFileClient(clientConfig, serverName, config, mcpUrl) {
 		const sseConfig = {
 			url: mcpUrl,
 		};
-		if (config.headers) {
-			sseConfig.headers = config.headers;
+		if (Object.keys(headers).length > 0) {
+			sseConfig.headers = headers;
 		}
 		existingConfig.mcpServers[serverName] = sseConfig;
 	} else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@boltic/cli",
-	"version": "1.0.46",
+	"version": "1.0.47",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@boltic/cli",
-			"version": "1.0.46",
+			"version": "1.0.47",
 			"cpu": [
 				"x64",
 				"arm64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@boltic/cli",
-	"version": "1.0.46",
+	"version": "1.0.47",
 	"description": "Professional CLI for interacting with the Boltic platform — create, manage, and publish integrations, serverless functions, workflows, MCPs, and more with enterprise-grade features and a seamless developer experience",
 	"main": "index.js",
 	"bin": {


### PR DESCRIPTION
Pass --header values as mcp-remote arguments for stdio clients instead of writing ignored headers config keys. Preserve Cursor SSE headers, add regression coverage, and bump the CLI to 1.0.47.